### PR TITLE
Remove ChipSelect default value in SpiConectionSettings

### DIFF
--- a/System.Device.Spi/SpiConnectionSettings.cs
+++ b/System.Device.Spi/SpiConnectionSettings.cs
@@ -38,8 +38,9 @@ namespace System.Device.Spi
         /// Initializes a new instance of the <see cref="SpiConnectionSettings"/> class.
         /// </summary>
         /// <param name="busId">The bus ID the device is connected to.</param>
-        /// <param name="chipSelectLine">The chip select line used on the bus. Optional, -1 if not used</param>
-        public SpiConnectionSettings(int busId, int chipSelectLine = -1)
+        /// <param name="chipSelectLine">The chip select line used on the bus. In .NET nanoFramework, you need to have a
+        /// valid GPIO Chip Select even if you don't use it.</param>
+        public SpiConnectionSettings(int busId, int chipSelectLine)
         {
             BusId = busId;
             ChipSelectLine = chipSelectLine;

--- a/Test/SpiHardwareUnitTests/SimpleSpiTests.cs
+++ b/Test/SpiHardwareUnitTests/SimpleSpiTests.cs
@@ -36,8 +36,7 @@ namespace SpiHardwareUnitTests
         public void CheckSpiConectionSettings()
         {
             // Arrange
-            SpiConnectionSettings connectinSettings = new SpiConnectionSettings(1);
-            connectinSettings.ChipSelectLine = 12;
+            SpiConnectionSettings connectinSettings = new SpiConnectionSettings(1, 12);
             connectinSettings.ChipSelectLineActiveState = PinValue.High;
             connectinSettings.ClockFrequency = 1_000_000;
             connectinSettings.DataBitLength = 8;


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Remove ChipSelect default value in SpiConectionSettings
- Adjusting intellisense comment 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- In .NET nanoFramework, all SPI need to have a valid Chip Select even if not used. 
- Removing the default constructor to avoid any issue

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
