### PR TITLE
Remove SharingMode from SpiConnectionSettings

### DIFF
--- a/System.Device.Spi/SpiConnectionSettings.cs
+++ b/System.Device.Spi/SpiConnectionSettings.cs
@@ -20,7 +20,6 @@ namespace System.Device.Spi
         // 1 byte
         private int _databitLength = 8;
         private SpiMode _spiMode = SpiMode.Mode0;
-        private SpiSharingMode _spiSharingMode;
         private DataFlow _dataFlow = DataFlow.MsbFirst;
         private int _busId;
         // Default is active low
@@ -55,8 +54,6 @@ namespace System.Device.Spi
             ClockFrequency = other.ClockFrequency;
             DataFlow = other.DataFlow;
             ChipSelectLineActiveState = other.ChipSelectLineActiveState;
-
-            SharingMode = other.SharingMode;
         }
 
         /// <summary>
@@ -144,19 +141,6 @@ namespace System.Device.Spi
         {
             get => _chipSelectLineActiveState;
             set => _chipSelectLineActiveState = value == PinValue.Low ? 0 : 1;
-        }
-
-        /// <summary>
-        /// Gets or sets the sharing mode for the SPI connection.
-        /// </summary>
-        public SpiSharingMode SharingMode
-        {
-            get => _spiSharingMode;
-
-            set
-            {
-                _spiSharingMode = value;
-            }
         }
 
         /// <summary>

--- a/Test/SpiHardwareUnitTests/SimpleSpiTests.cs
+++ b/Test/SpiHardwareUnitTests/SimpleSpiTests.cs
@@ -42,7 +42,6 @@ namespace SpiHardwareUnitTests
             connectinSettings.DataBitLength = 8;
             connectinSettings.DataFlow = DataFlow.LsbFirst;
             connectinSettings.Mode = SpiMode.Mode2;
-            connectinSettings.SharingMode = SpiSharingMode.Exclusive;
 
             // Assert
             Assert.Equal(12, connectinSettings.ChipSelectLine);
@@ -51,7 +50,6 @@ namespace SpiHardwareUnitTests
             Assert.Equal(8, connectinSettings.DataBitLength);
             Assert.True(DataFlow.LsbFirst == connectinSettings.DataFlow);
             Assert.True(SpiMode.Mode2 == connectinSettings.Mode);
-            Assert.True(SpiSharingMode.Exclusive == connectinSettings.SharingMode);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
- Remove the property and update Unit Tests.

## Motivation and Context
- This property was a leftover from UWP API.
- Never had any implementation at hardware level.
- Does not exist on .NET IoT API.
- OK to skip deprecation notice period because of all the above.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
