### PR TITLE
Fix unit tests for VS17.3

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -5,7 +5,8 @@
        <MaxCpuCount>1</MaxCpuCount>
        <ResultsDirectory>.\TestResults</ResultsDirectory><!-- Path relative to solution directory -->
        <TestSessionTimeout>120000</TestSessionTimeout><!-- Milliseconds -->
-       <TargetFrameworkVersion>Framework40</TargetFrameworkVersion>
+       <TargetFrameworkVersion>net48</TargetFrameworkVersion>
+       <TargetPlatform>x64</TargetPlatform>
    </RunConfiguration>
    <nanoFrameworkAdapter>
        <Logging>None</Logging>

--- a/System.Device.Spi/System.Device.Spi.nfproj
+++ b/System.Device.Spi/System.Device.Spi.nfproj
@@ -19,7 +19,6 @@
     <NF_IsCoreLibrary>True</NF_IsCoreLibrary>
     <DocumentationFile>bin\$(Configuration)\System.Device.Spi.xml</DocumentationFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode Condition="'$(TF_BUILD)' == 'True' or '$(ContinuousIntegrationBuild)' == 'True'">true</RestoreLockedMode>
   </PropertyGroup>
   <PropertyGroup>

--- a/Test/SpiHardwareUnitTests/SpiHardwareUnitTests.nfproj
+++ b/Test/SpiHardwareUnitTests/SpiHardwareUnitTests.nfproj
@@ -26,9 +26,6 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <PropertyGroup>
-    <RunSettingsFilePath>$(MSBuildProjectDirectory)\nano.runsettings</RunSettingsFilePath>
-  </PropertyGroup>
-  <PropertyGroup>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
@@ -64,7 +61,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="nano.runsettings" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ steps:
   parameters:
     sonarCloudProject: 'nanoframework_System.Device.Spi'
     runUnitTests: false
-    unitTestRunsettings: '$(System.DefaultWorkingDirectory)\Test\SpiHardwareUnitTests\nano.runsettings'
+    unitTestRunsettings: '$(System.DefaultWorkingDirectory)\.runsettings'
 
 # step from template @ nf-tools repo
 # report error

--- a/nanoFramework.System.Device.Spi.sln
+++ b/nanoFramework.System.Device.Spi.sln
@@ -9,6 +9,7 @@ Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "SpiHardwareUnitTests", "Tes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F590E4F6-965B-4148-8482-B1B746073606}"
 	ProjectSection(SolutionItems) = preProject
+		.runsettings = .runsettings
 		nanoFramework.System.Device.Spi.nuspec = nanoFramework.System.Device.Spi.nuspec
 		README.md = README.md
 		version.json = version.json


### PR DESCRIPTION
## Description
* Fixes unit tests.
* `<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>` was duplicated...

## Motivation and Context
* They were broken!


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
